### PR TITLE
Remove old refs

### DIFF
--- a/varnish_book.rst
+++ b/varnish_book.rst
@@ -3529,9 +3529,8 @@ among a list of possibles.  This allows dynamic scaling and changing of web
 server pools without modifying Varnish' configuration, but instead just
 waiting for Varnish to pick up on the DNS changes.
 
-As the DNS director is both the newest addition and perhaps the most
-complex, some extra explanation might be useful. Consider the following
-example VCL.
+As the DNS director is perhaps the most complex, some extra
+explanation might be useful. Consider the following example VCL.
 
 .. include:: vcl/dns_director.vcl
    :literal:


### PR DESCRIPTION
Remove a couple of explicit references to "this is the newest" and "this was added in varnish 2.1", for consistency. If we want to include those, we should include them everywhere, not just randomly in one section.
