### PR TITLE
Added setting the default timezone value

### DIFF
--- a/material/webdev/httpheadersexample.php
+++ b/material/webdev/httpheadersexample.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('UTC');
 define( 'LAST_MODIFIED_STRING', 'Sat, 09 Sep 2000 22:00:00 GMT' );
 
 // expires_date : 10s after page generation


### PR DESCRIPTION
Set the date default timezone value as this was causing errors on a
standard PHP install on CentOS running PHP 5.3.23