### PR TITLE
Replace debug.health with backend.list -p

### DIFF
--- a/varnish_book.rst
+++ b/varnish_book.rst
@@ -2051,7 +2051,6 @@ Tunable Parameters
 
    A few debug commands exist in the CLI, which can be revealed with ``help -d``. 
    These commands are meant exclusively for development or testing, and many of them are downright dangerous. 
-   They are hidden for a reason, and the only exception is perhaps ``debug.health``, which is somewhat common to use.
 
    .. tip::
 
@@ -4830,7 +4829,7 @@ Analyzing health probes
       # varnishlog -g raw -i Backend_health
       0 Backend_health - default Still healthy 4--X-RH 5 3 5 0.012166 0.013693 HTTP/1.0 200 OK
 
-- ``varnishadm debug.health``::
+- ``varnishadm backend.list -p``::
 
       Backend default is Healthy
       Current states  good:  5 threshold:  3 window:  5
@@ -4895,9 +4894,9 @@ Analyzing health probes
    Note that `Still` indicates unchanged state, `Back` and `Went` indicate a change of state.
    The second word indicates the present state.
 
-   .. varnishadm debug.health
+   .. varnishadm backend.list -p
 
-   Another method to analyze health probes is by calling ``varnishadm debug.health``.
+   Another method to analyze health probes is by calling ``varnishadm backend.list -p``.
    This command presents first data from the last ``Backend_health`` log::
 
      Backend default is Healthy
@@ -4915,7 +4914,8 @@ Analyzing health probes
 
    .. varnishadm backend.list
 
-   Still another form to analyze your probes is by calling ``varnishadm backend.list``.
+   Still another form to analyze your probes is by calling ``varnishadm backend.list``
+   without the -p parameter.
    At this point, the output of this command should be clear for the careful reader.
 
 Demo: Health Probes
@@ -4928,7 +4928,7 @@ See the power of health probes!
    Suggested steps for the demo:
 
    #. Configure a probe like in `Health Checks`_.
-   #. Run ``watch -n.5 "varnishadm debug.health"`` in one terminal
+   #. Run ``watch -n.5 "varnishadm backend.list -p"`` in one terminal
    #. Run ``watch -n.5 "varnishadm backend.list"`` in another terminal
    #. Start and stop your backend
       For this, you might want to simulate very quickly a backend with the command ``python -m SimpleHTTPServer [port]``.


### PR DESCRIPTION
debug.health doesn't exist anymore and has been replaced with a more
appropriately named "backend.list -p".