### PR TITLE
Fixing/updating "Rewrite URL and Host Header Fields"

### DIFF
--- a/varnish_book.rst
+++ b/varnish_book.rst
@@ -7951,23 +7951,24 @@ Solution: Rewrite URL and Host Header Fields
 ::
 
  sub vcl_recv {
+       set req.http.x-host = req.http.host;
+       set req.http.x-url = req.url;
+       
+       /* Alternative 1 */
+       set req.http.host = regsub(req.http.host, "^sport\.", "");
+       set req.url = "/sport" + req.url;
 
-     set req.http.x-host = req.http.host;
-     set req.http.x-url = req.url;
+       /* Alternative 2 */
+       #if (req.http.host == "sport.example.com") {
+       #    set req.http.host = "example.com";
+       #    set req.url = "/sport" + req.url;
+       #}
 
-     set req.http.host = regsub(req.http.host, "^www\.", "");
-
-     /* Alternative 1 */
-     if (req.http.host == "sport.example.com") {
-         set req.http.host = "example.com";
-         set req.url = "/sport" + req.url;
-      }
-
-      /* Alternative 2 */
-      if (req.http.host ~ "^sport\.") {
-        set req.http.host = regsub(req.http.host,"^sport\.", "");
-        set req.url = regsub(req.url, "^", "/sport");
-      }
+       /* Alternative 3 */
+       #if (req.http.host ~ "^sport\.") {
+       #    set req.http.host = regsub(req.http.host,"^sport\.", "");
+       #    set req.url = regsub(req.url, "^", "/sport");
+       #}
  }
 
 .. container:: handout

--- a/vtc/b00010.vtc
+++ b/vtc/b00010.vtc
@@ -2,32 +2,33 @@ varnishtest "Rewrite URL and Host Header Fields"
 
 server s1 {
         rxreq
-        expect req.http.Host == "example.com"
-        expect req.http.ReqURL == "/sport/index.html"
+        expect req.http.x-host == "sport.example.com"
+        expect req.http.x-url == "/index.html"
+        expect req.http.host == "example.com"
+        expect req.url == "/sport/index.html"
         txresp
-}
+} -start
 
-varnish v1 -vcl {
-   backend default {
-      .host = "93.184.216.34"; # example.com
-      .port = "80";
-   }
+varnish v1 -vcl+backend {
    sub vcl_recv {
        set req.http.x-host = req.http.host;
        set req.http.x-url = req.url;
-       set req.http.host = regsub(req.http.host, "^www\.", "");
-
+       
        /* Alternative 1 */
-       if (req.http.host == "sport.example.com") {
-           set req.http.host = "example.com";
-           set req.url = "/sport" + req.url;
-       }
+       set req.http.host = regsub(req.http.host, "^sport\.", "");
+       set req.url = "/sport" + req.url;
 
        /* Alternative 2 */
-       # if (req.http.host ~ "^sport\.") {
-       #     set req.http.host = regsub(req.http.host,"^sport\.", "");
-       #     set req.url = regsub(req.url, "^", "/sport");
-       # }
+       #if (req.http.host == "sport.example.com") {
+       #    set req.http.host = "example.com";
+       #    set req.url = "/sport" + req.url;
+       #}
+
+       /* Alternative 3 */
+       #if (req.http.host ~ "^sport\.") {
+       #    set req.http.host = regsub(req.http.host,"^sport\.", "");
+       #    set req.url = regsub(req.url, "^", "/sport");
+       #}
    }
 } -start
 


### PR DESCRIPTION
First, let me say I have only a couple of hours of experience with Varnish, mainly following the steps and instructions within this very book.

So, it was strange when trying to reproduce this specific example, because it seems to be badly constructed. Please, feel free to correct me as, again, I do not have experience.

But consider this:

- It did not matter what you had in the `expect` clauses in the `server s1`, since the server was not started and a different backend was configured anyway, so those clauses were never executed
  - I even added gibberish in there and still the test passed;
  - I changed this by adding `+backend` and erasing the "explicit" backend configuration to `varnish v1`, and adding `-start` to `server s1`;
- Some of the rules considered "www.example.com" instead of "sport.example.com" and, therefore, would also not apply correctly to the test case;
- Added a couple more `expect` clauses to cover all the modified headers;