### PR TITLE
Do not use new line in http header

### DIFF
--- a/material/webdev/httpheadersexample.php
+++ b/material/webdev/httpheadersexample.php
@@ -20,14 +20,12 @@ if( isset( $_GET['h'] ) and $_GET['h'] !== '' )
         break;
 
         case "cache-control":
-            $headers['Cache-Control'] = "public, must-revalidate, 
-	    max-age=3600, s-maxage=3600";
+            $headers['Cache-Control'] = "public, must-revalidate, max-age=3600, s-maxage=3600";
         break;
 
         case "cache-control-override":
             $headers['Expires'] = toUTCDate($expires_date);
-            $headers['Cache-Control'] = "public, must-revalidate, 
-	    max-age=2, s-maxage=2";
+            $headers['Cache-Control'] = "public, must-revalidate, max-age=2, s-maxage=2";
         break;
 
         case "last-modified":


### PR DESCRIPTION
The httpheadersexample.php uses a newline inside the `Cache-Control` headers, which actually breaks them. They show up in the browser in the body/content but not as actual HTTP headers. 

Original file:

``` 
# curl -I "http://localhost:8080/httpheadersexample.php?h=cache-control" -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> HEAD /httpheadersexample.php?h=cache-control HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Mon, 25 Nov 2019 14:15:48 GMT
Date: Mon, 25 Nov 2019 14:15:48 GMT
< Server: Apache/2.4.29 (Ubuntu)
Server: Apache/2.4.29 (Ubuntu)
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
```

After adapting it and not using a new line within the `Cache-Control` string:

```
# curl -I "http://localhost:8080/httpheadersexample.php?h=cache-control" -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> HEAD /httpheadersexample.php?h=cache-control HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Mon, 25 Nov 2019 14:16:34 GMT
Date: Mon, 25 Nov 2019 14:16:34 GMT
< Server: Apache/2.4.29 (Ubuntu)
Server: Apache/2.4.29 (Ubuntu)
< Cache-Control: public, must-revalidate, max-age=3600, s-maxage=3600
Cache-Control: public, must-revalidate, max-age=3600, s-maxage=3600
< Content-Type: text/html; charset=UTF-8
Content-Type: text/html; charset=UTF-8
```

Tested with PHP 7.2.